### PR TITLE
chore: pin backend dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Backend dependency management
+
+The backend's requirements file (`be/requirements.txt`) now pins explicit versions for its core packages.
+To update these versions after modifying dependencies:
+
+```sh
+pip install -r be/requirements.txt
+pip freeze | grep -E '^(fastapi|uvicorn|transformers|torchaudio|torch|TTS)=' > be/requirements.txt
+```
+
+This process ensures that the recorded dependencies match the installed packages.

--- a/be/requirements.txt
+++ b/be/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-uvicorn
-transformers
-torchaudio
-torch
-TTS
+fastapi==0.116.1
+uvicorn==0.35.0
+transformers==4.55.0
+torchaudio==2.8.0
+torch==2.8.0
+TTS==0.22.0


### PR DESCRIPTION
## Summary
- pin backend requirements with explicit versions
- document pip-freeze workflow for backend dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894b36d7340832a9d00cc71048c62b8