### PR TITLE
Fix backend module path and FastAPI initialization

### DIFF
--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application package."""

--- a/be/main.py
+++ b/be/main.py
@@ -1,6 +1,6 @@
-from fastapi import fastapi
+from fastapi import FastAPI
 
-app = fastapi()
+app = FastAPI()
 
 @app.get("/")
 def root():

--- a/be/run.py
+++ b/be/run.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.server:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- fix run module to target app.server
- correct FastAPI import in main
- mark app directory as a Python package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894bb2935f0832ab3eb45fbf7e647cc