### PR TITLE
Use npm ci for deterministic frontend builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Stage 1: Build the React frontend
 FROM node:18-alpine AS frontend
 WORKDIR /app
-COPY fe/package*.json ./
-RUN npm install
+COPY fe/package.json fe/package-lock.json ./
+RUN npm ci
 COPY fe/ .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- use `npm ci` instead of `npm install` for building frontend assets
- copy `package-lock.json` into Docker build context to honor lockfile

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest` (0 tests ran)


------
https://chatgpt.com/codex/tasks/task_e_6894ea2d5040832a9c77b6d38c9f5599