### PR TITLE
feat: make WebSocket URL configurable

### DIFF
--- a/fe/.env.example
+++ b/fe/.env.example
@@ -1,0 +1,3 @@
+# Frontend environment variables
+# WebSocket URL for VoiceChatPage; defaults to current host when not set
+VITE_WS_URL=ws://localhost:8000/ws

--- a/fe/src/components/VoiceChatPage.tsx
+++ b/fe/src/components/VoiceChatPage.tsx
@@ -63,7 +63,9 @@ const VoiceChatPage = () => {
     // Reset message history for new call
     setMessages([]);
 
-    const ws = new WebSocket("ws://localhost:8000/ws");
+    const defaultWsUrl = `${window.location.origin.replace(/^http/, "ws")}/ws`;
+    const wsUrl = import.meta.env.VITE_WS_URL || defaultWsUrl;
+    const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
     // --- WEBSOCKET LOGIC CHANGE: Handle both user and AI messages ---


### PR DESCRIPTION
## Summary
- read WebSocket endpoint from `VITE_WS_URL` or default to current host
- document `VITE_WS_URL` in `.env.example`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint found errors)


------
https://chatgpt.com/codex/tasks/task_e_6894ea1ee9b0832a9b52b47a59ef68be